### PR TITLE
feat: Add time and log based liquidation

### DIFF
--- a/contracts/LogLiquidationAutomation.sol
+++ b/contracts/LogLiquidationAutomation.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./Perps.sol";
+
+/**
+ * @title LogLiquidationAutomation
+ * @dev Log-based automation - triggers on position opens/closes
+ */
+contract LogLiquidationAutomation {
+    Perps public perpsContract;
+    uint256 public lastRun;
+    address public owner;
+
+    event LogTriggeredLiquidation(
+        uint256 positionsLiquidated,
+        uint256 timestamp
+    );
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Only owner");
+        _;
+    }
+
+    constructor(address _perpsContract) {
+        perpsContract = Perps(_perpsContract);
+        owner = msg.sender;
+    }
+
+    /**
+     * @dev Check if liquidation needed based on position events
+     */
+    function checkLog(Log calldata log, bytes memory)
+        external
+        pure
+        returns (bool upkeepNeeded, bytes memory)
+    {
+        // Only trigger on position opens/closes (when fresh prices are fetched)
+        bytes32 positionOpened = keccak256(
+            "PositionOpened(address,string,uint256,uint256,uint256,bool,uint256)"
+        );
+        bytes32 positionClosed = keccak256(
+            "PositionClosed(address,string,int256,uint256)"
+        );
+
+        return (
+            log.topics[0] == positionOpened || log.topics[0] == positionClosed,
+            ""
+        );
+    }
+
+    /**
+     * @dev Perform liquidations after position activity
+     */
+    function performUpkeep(bytes calldata) external {
+        // Rate limit - max once per minute
+        require(block.timestamp > lastRun + 60, "Too frequent");
+
+        uint256 liquidated = perpsContract.liquidatePositions();
+        lastRun = block.timestamp;
+
+        emit LogTriggeredLiquidation(liquidated, block.timestamp);
+    }
+
+    // Emergency functions
+    function updatePerpsContract(address _newPerps) external onlyOwner {
+        perpsContract = Perps(_newPerps);
+    }
+
+    function forceRun() external onlyOwner {
+        uint256 liquidated = perpsContract.liquidatePositions();
+        lastRun = block.timestamp;
+        emit LogTriggeredLiquidation(liquidated, block.timestamp);
+    }
+}
+
+// Log struct for Chainlink Log Trigger
+struct Log {
+    uint256 index;
+    uint256 timestamp;
+    bytes32 txHash;
+    uint256 blockNumber;
+    bytes32 blockHash;
+    address source;
+    bytes32[] topics;
+    bytes data;
+}

--- a/contracts/PerpsEvents.sol
+++ b/contracts/PerpsEvents.sol
@@ -19,6 +19,12 @@ contract PerpsEvents {
         uint256 holdingFees
     );
 
+    event PositionLiquidated(
+        address indexed user,
+        string symbol,
+        uint256 collateralLost,
+        address indexed liquidator
+    );
     
     event MarketAdded(string symbol, uint256 maxLeverage);
     event Deposit(address indexed user, uint256 amount);

--- a/contracts/PriceOracle.sol
+++ b/contracts/PriceOracle.sol
@@ -23,7 +23,12 @@ contract PriceOracle {
     uint256 public constant UPDATE_INTERVAL = 1 hours;
 
     event PriceFeedUpdated(string symbol, address feedAddress);
-    event DailyDataUpdated(string symbol, uint256 high, uint256 low, uint256 change);
+    event DailyDataUpdated(
+        string symbol,
+        uint256 high,
+        uint256 low,
+        uint256 change
+    );
 
     constructor() {
         _setPriceFeed("BTC/USD", 0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43);
@@ -43,7 +48,7 @@ contract PriceOracle {
      * @dev Get current price from Chainlink
      * @return normalizedPrice Price with 8 decimals (divide by 1e8 for actual price)
      * @return updatedAt Timestamp when price was last updated
-     * 
+     *
      * FRONTEND EXPLANATION:
      * - BTC/USD returns: 10924049875600 = $109,240.49875600 (divide by 1e8)
      * - ETH/USD returns: 267698271300 = $2,676.98271300 (divide by 1e8)
@@ -80,130 +85,5 @@ contract PriceOracle {
         }
 
         return (normalizedPrice, updatedAtChainlink);
-    }
-
-    /**
-     * @dev View 24h data WITHOUT updating state 
-     * @notice ⚠️ This shows historical data only - may be stale or show zeros if never updated
-     * @notice Call get24hData() first to initialize/update the tracking data
-     * 
-     * FRONTEND USAGE:
-     * - Use this for quick reads without gas costs
-     * - But call get24hData() periodically to update the underlying data
-     * - If all values are 0, it means get24hData() was never called for this symbol
-     */
-    function view24hDataWithoutUpdate(string memory symbol)
-        external
-        view
-        returns (
-            uint256 currentPrice,
-            uint256 high24h,
-            uint256 low24h,
-            uint256 priceChange,
-            int256 changePercent
-        )
-    {
-        (currentPrice, ) = this.getPrice(symbol);
-        DailyData memory daily = dailyData[symbol];
-
-        // Calculate change with existing data (may be stale)
-        if (daily.price24hAgo > 0) {
-            if (currentPrice >= daily.price24hAgo) {
-                priceChange = currentPrice - daily.price24hAgo;
-                changePercent = int256((priceChange * 10000) / daily.price24hAgo);
-            } else {
-                priceChange = daily.price24hAgo - currentPrice;
-                changePercent = -int256((priceChange * 10000) / daily.price24hAgo);
-            }
-        }
-
-        return (currentPrice, daily.high24h, daily.low24h, priceChange, changePercent);
-    }
-
-    /**
-     * @dev Get 24h data WITH state updates (always fresh and accurate)
-     * @notice This updates the tracking data and returns current 24h statistics
-     * FRONTEND USAGE:
-     * - Call this function to get updated 24h data
-     * - Set up periodic calls (every 1-4 hours) for better accuracy
-     * - Price values need to be divided by 1e8 for display
-     */
-    function get24hData(string memory symbol)
-        external
-        returns (
-            uint256 currentPrice, // Divide by 1e8 for actual price
-            uint256 high24h,// Divide by 1e8 for actual price
-            uint256 low24h,// Divide by 1e8 for actual price
-            uint256 priceChange, // Absolute change (divide by 1e8)
-            int256 changePercent // Percentage in basis points (150 = 1.50%)
-        )
-    {
-        (currentPrice, ) = this.getPrice(symbol);
-        
-        // Update daily tracking with current price
-        _updateDailyData(symbol, currentPrice);
-        
-        DailyData memory daily = dailyData[symbol];
-
-        // Calculate change with updated data
-        if (daily.price24hAgo > 0) {
-            if (currentPrice >= daily.price24hAgo) {
-                priceChange = currentPrice - daily.price24hAgo;
-                changePercent = int256((priceChange * 10000) / daily.price24hAgo);
-            } else {
-                priceChange = daily.price24hAgo - currentPrice;
-                changePercent = -int256((priceChange * 10000) / daily.price24hAgo);
-            }
-        }
-
-        return (currentPrice, daily.high24h, daily.low24h, priceChange, changePercent);
-    }
-
-    /**
-     * @dev Update 24h data manually
-     */
-    function update24hData(string memory symbol) external {
-        (uint256 currentPrice, ) = this.getPrice(symbol);
-        _updateDailyData(symbol, currentPrice);
-    }
-
-    /**
-     * @dev Internal: Update 24h tracking data
-     * 
-     * WHY THE 24H CONDITION?
-     * Every 24 hours, we need to "reset" our tracking window:
-     * - Set new "24h ago" price (current price becomes the new baseline)
-     * - Reset high/low to current price (start fresh 24h window)
-     * 
-     * Without this reset, we'd track data from the beginning of time,
-     * not just the last 24 hours.
-     */
-    function _updateDailyData(string memory symbol, uint256 currentPrice) internal {
-        DailyData storage daily = dailyData[symbol];
-
-        // RESET CONDITION: First time OR 24 hours have passed
-        if (
-            daily.lastUpdateTime == 0 ||                              // First time
-            block.timestamp >= daily.lastUpdateTime + 24 hours        // 24h window ended
-        ) {
-            // Start new 24h tracking window
-            daily.price24hAgo = currentPrice;    // Current price becomes "24h ago" baseline
-            daily.high24h = currentPrice;        // Reset high to current
-            daily.low24h = currentPrice;         // Reset low to current
-            daily.lastUpdateTime = block.timestamp;  // Mark start of new window
-        }
-        // UPDATE CONDITION: Within same 24h window
-        else {
-            // Just update high/low within current window
-            if (currentPrice > daily.high24h) {
-                daily.high24h = currentPrice;
-            }
-            if (currentPrice < daily.low24h) {
-                daily.low24h = currentPrice;
-            }
-        }
-
-        lastDailyUpdate[symbol] = block.timestamp;
-        emit DailyDataUpdated(symbol, daily.high24h, daily.low24h, currentPrice);
     }
 }

--- a/contracts/TimeLiquidationAutomation.sol
+++ b/contracts/TimeLiquidationAutomation.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./Perps.sol";
+
+/**
+ * @title TimeLiquidationAutomation  
+ * @dev Time-based automation - every 4 hours for holding fees
+ */
+contract TimeLiquidationAutomation {
+    Perps public perpsContract;
+    uint256 public lastRun;
+    address public owner;
+    
+    event AutoLiquidationExecuted(uint256 positionsLiquidated, uint256 timestamp);
+    
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Only owner");
+        _;
+    }
+    
+    constructor(address _perpsContract) {
+        perpsContract = Perps(_perpsContract);
+        lastRun = block.timestamp;
+        owner = msg.sender;
+    }
+    
+    function checkUpkeep(bytes calldata) 
+        external 
+        view 
+        returns (bool upkeepNeeded, bytes memory) 
+    {
+        upkeepNeeded = (block.timestamp - lastRun) >= 4 hours;
+        return (upkeepNeeded, "");
+    }
+    
+    function performUpkeep(bytes calldata) external {
+        require((block.timestamp - lastRun) >= 4 hours, "Too soon");
+        
+        uint256 liquidated = perpsContract.liquidatePositions();
+        lastRun = block.timestamp;
+        
+        emit AutoLiquidationExecuted(liquidated, block.timestamp);
+    }
+    
+    // Emergency functions
+    function updatePerpsContract(address _newPerps) external onlyOwner {
+        perpsContract = Perps(_newPerps);
+    }
+    
+    function forceRun() external onlyOwner {
+        uint256 liquidated = perpsContract.liquidatePositions();
+        lastRun = block.timestamp;
+        emit AutoLiquidationExecuted(liquidated, block.timestamp);
+    }
+}


### PR DESCRIPTION
Liquidation is triggered when `canLiquidate()` returns true for a position.

From `PerpsCalculations.sol`, `canLiquidate()` depends on:
```
currentCollateralValue = initial collateral + PnL - holding fees
return currentCollateralValue <= requiredMargin;
```

✅ What triggers liquidations:

1. `openPosition()` → fetches fresh price
2. `closePosition()` → fetches fresh price
3. Time passing → holding fees accumulate

Therefore the automation setup must include:

1. Time-based: Every 4 hours
2. Log-based: On `PositionOpened`/`PositionClosed` events only


Keeping all this in mind, in this PR:
- Removed dead code 24 hour data function from priceOracle. These are being implemented using dataStreams now
- Added liquidationPosition and helper functions in perps.sol
- Added 2 types of automation: 
1. `TimeLiquidationAutomation` - Runs every 4 hours to catch positions decaying over time
2. `LogLiquidationAutomation` - Runs on PositionOpened and PositionClosed events


